### PR TITLE
chore: Change port to 8005 and add deployment script

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,8 +5,9 @@
   "scripts": {
     "dev": "next dev -p 8005",
     "build": "next build",
-    "start": "next start",
-    "lint": "next lint"
+    "start": "next start -p 8005",
+    "lint": "next lint",
+    "deploy":"bun run build && bun run start"
   },
   "dependencies": {
     "@hookform/resolvers": "latest",


### PR DESCRIPTION
Changed the port in production from 3000 to 8005 and deployment script so it can be easily deployed with just single script